### PR TITLE
NOJS init quaranteens repl-less cyoa 

### DIFF
--- a/CSS/uploaded-to-ao3-v7_2.css
+++ b/CSS/uploaded-to-ao3-v7_2.css
@@ -18,7 +18,7 @@
     width: 20%;
 } */
 
-.expanded::after,#workskin .collapsed::after{
+.expanded::after, .collapsed::after{
     display:none
 }
 

--- a/CSS/uploaded-to-ao3-v7_2.css
+++ b/CSS/uploaded-to-ao3-v7_2.css
@@ -1,7 +1,27 @@
-.cyoa-choice-5 {
-    display: inline;
+/* .cyoa-choice-5 {
+    display: inline-block;
+} */
+
+/* .convo-container.choices {
+    max-width: unset;
+    min-width: unset;
+    display: block;
 }
 
+.cyoa-choice-5.right {
+    margin-right: 25%;
+    width: 20%;
+}
+
+.cyoa-choice-5.left {
+    margin-left: 30%;
+    width: 20%;
+} */
+
+.anh.region , .fakenotes , .bline.actions {
+    font-family: initial;
+    font-size: initial;
+}
 
 a.expanded, 
 .expandable.hidden, 
@@ -50,33 +70,43 @@ a.expanded,
 }
 
 .expanded ~ .expanded ~ .expanded ~ .expanded ~ .expanded ~ .rootTabStuff,
+.expanded ~ .expanded ~ .expanded ~ .expanded ~ .expanded ~ .startTabStuff,
 #start:target ~ .root .rootTabStuff,
 #start2:target ~ .root .rootTabStuff
 {
-    display: none;
+    display: none !important;
 }
 
 /* customizations within .root */
 #start:target ~ .root .startTabStuff,
 #start2:target ~ .root .start2TabStuff
 {
-    display: block !important;
+    display: block;
 }
 
 #start:target ~ .root .startTabStuff.convo-container,
 #start2:target ~ .root .start2TabStuff.convo-container
 {
-    display: table;
+    display: block;
 }
 
 .expanded ~ .expanded ~ .expanded ~ .expanded ~ .expanded ~ .start2TabStuff {
     display: block;
 }
 
-.convo-container.choices {
-    max-width: unset;
-    min-width: unset;
-    display: block;
+.cyoa-start-over.start2
+{
+    display: none;
+}
+
+.root:has(.expanded ~ .expanded ~ .expanded ~ .expanded ~ .expanded) ~ .tab .cyoa-start-over.start2
+{
+    display: inline-block;
+}
+
+.root:has(.expanded ~ .expanded ~ .expanded ~ .expanded ~ .expanded) ~ .tab .cyoa-start-over.start1
+{
+    display: none;
 }
 
 /* to dos:
@@ -86,4 +116,5 @@ update x images in start and start2
 -combine root and start (and start2?) but flip the endnotes / dialogues
 -make start2 separate tab?? make it show, its not showing
 update css for ao3 friendly (collapsed/ expanded)
+fix 4 + 1 + 1 choices view on mobile 
 */

--- a/CSS/uploaded-to-ao3-v7_2.css
+++ b/CSS/uploaded-to-ao3-v7_2.css
@@ -1,0 +1,89 @@
+.cyoa-choice-5 {
+    display: inline;
+}
+
+
+a.expanded, 
+.expandable.hidden, 
+.expandable.askNoneBtn {
+    display: none !important;
+}
+
+.ventBtn, .askNoneBtn {
+    display: none;
+}
+
+.expanded ~ .askNoneBtn {
+    display: inline-block;
+}
+
+.expanded ~ .expanded ~ .expanded ~ .expanded ~ .expanded ~ .ventBtn {
+    display: inline-block;
+}
+
+/* .expandable.placeholder {
+    display: none;
+} */
+
+/* .expanded:nth-of-type(3) ~ .ventBtn {
+    display: inline-block;
+} */
+
+#ask-sam:target ~ .default-tab,
+#ask-tucker:target ~ .default-tab,
+#ask-jazz:target ~ .default-tab,
+#ask-elle:target ~ .default-tab,
+#ask-none:target ~ .default-tab,
+#vent:target ~ .default-tab
+{
+    display: none;
+}
+
+.startTabStuff, .start2TabStuff {
+    display: none;
+}
+
+#start:target ~ .root, /* after making 1 choice */
+#start2:target ~ .root /* after making all 5 choices */
+{
+    display: block !important;
+}
+
+.expanded ~ .expanded ~ .expanded ~ .expanded ~ .expanded ~ .rootTabStuff,
+#start:target ~ .root .rootTabStuff,
+#start2:target ~ .root .rootTabStuff
+{
+    display: none;
+}
+
+/* customizations within .root */
+#start:target ~ .root .startTabStuff,
+#start2:target ~ .root .start2TabStuff
+{
+    display: block !important;
+}
+
+#start:target ~ .root .startTabStuff.convo-container,
+#start2:target ~ .root .start2TabStuff.convo-container
+{
+    display: table;
+}
+
+.expanded ~ .expanded ~ .expanded ~ .expanded ~ .expanded ~ .start2TabStuff {
+    display: block;
+}
+
+.convo-container.choices {
+    max-width: unset;
+    min-width: unset;
+    display: block;
+}
+
+/* to dos:
+-make "expanded" untoggleable 
+-test w <detail> <summary><a href="">asdf </a></summary></detail>
+update x images in start and start2
+-combine root and start (and start2?) but flip the endnotes / dialogues
+-make start2 separate tab?? make it show, its not showing
+update css for ao3 friendly (collapsed/ expanded)
+*/

--- a/CSS/uploaded-to-ao3-v7_2.css
+++ b/CSS/uploaded-to-ao3-v7_2.css
@@ -18,10 +18,14 @@
     width: 20%;
 } */
 
-.anh.region , .fakenotes , .bline.actions {
+.expanded::after,#workskin .collapsed::after{
+    display:none
+}
+
+/* .anh.region , .fakenotes , .bline.actions {
     font-family: initial;
     font-size: initial;
-}
+} */
 
 a.expanded, 
 .expandable.hidden, 

--- a/Quaranteens/quarantine-6v3.html
+++ b/Quaranteens/quarantine-6v3.html
@@ -208,46 +208,47 @@ eventual order for copy paste:
 <!-- show 4 + 1 + 1 options -->
 <div class="convo-container tall choices">
     <p class="convo-break"></p>
-    <a class="cyoa-choice-5 collapsed" href="#ask-jazz">
+    <a class="cyoa-choice-5 left collapsed" href="#ask-jazz">
         <span class="">Ask Jazz =></span> 
         <!-- <img class="cyoa-visited" src="https://i.imgur.com/8ehwsNR.png" > -->
-    </a> <a class="cyoa-choice-5 expandable" href="#ask-jazz">
+    </a> <a class="cyoa-choice-5 left expandable" href="#ask-jazz">
         <span class="">Ask Jazz =></span> 
         <img class="cyoa-visited" src="https://i.imgur.com/8ehwsNR.png" >
-    </a> <a class="cyoa-choice-5 collapsed" href="#ask-sam">
+    </a> <a class="cyoa-choice-5 right collapsed" href="#ask-sam">
         <span class="">Ask Sam =></span>  
         <!-- <img class="cyoa-visited" src="https://i.imgur.com/8ehwsNR.png" > -->
-    </a> <a class="cyoa-choice-5 expandable" href="#ask-sam">
+    </a> <a class="cyoa-choice-5 right expandable" href="#ask-sam">
         <span class="">Ask Sam =></span>  
         <img class="cyoa-visited" src="https://i.imgur.com/8ehwsNR.png" >
     </a> 
     <br /><br />
-    <a class="cyoa-choice-5 collapsed" href="#ask-tucker">
+    <a class="cyoa-choice-5 left collapsed" href="#ask-tucker">
         <span class="">Ask Tucker =></span> 
         <!-- <img class="cyoa-visited" src="https://i.imgur.com/8ehwsNR.png" > -->
-    </a> <a class="cyoa-choice-5 expandable" href="#ask-tucker">
+    </a> <a class="cyoa-choice-5 left expandable" href="#ask-tucker">
         <span class="">Ask Tucker =></span> 
         <img class="cyoa-visited" src="https://i.imgur.com/8ehwsNR.png" >
-    </a>  <a class="cyoa-choice-5 collapsed" href="#ask-elle">
+    </a>  <a class="cyoa-choice-5 right collapsed" href="#ask-elle">
         <span class="">Ask Elle =></span> 
         <!-- <img class="cyoa-visited" src="https://i.imgur.com/8ehwsNR.png" > -->
-    </a> <a class="cyoa-choice-5 expandable" href="#ask-elle">
+    </a> <a class="cyoa-choice-5 right expandable" href="#ask-elle">
         <span class="">Ask Elle =></span> 
         <img class="cyoa-visited" src="https://i.imgur.com/8ehwsNR.png" >
     </a> 
     <br /><br />
-    <a class="cyoa-choice-5 collapsed askNoneBtn" href="#ask-none">
+    <a class="cyoa-choice-5  left collapsed askNoneBtn" href="#ask-none">
         <span class="">Ask no one =></span>
         <!-- <img class="cyoa-visited" src="https://progress-tracker.mystyrust.repl.co/images/ask-none/visited.png" > -->
-    </a> <a class="cyoa-choice-5 expandable" href="#ask-none">
+    </a> <a class="cyoa-choice-5  left expandable" href="#ask-none">
         <span class="">Ask no one =></span>
         <img class="cyoa-visited" src="https://i.imgur.com/8ehwsNR.png" >
     </a>
-    <a class="cyoa-choice-5 ventBtn" href="#vent">
+    <a class="cyoa-choice-5 right ventBtn" href="#vent">
         <span class="">Vent =></span>
         <!-- <img class="cyoa-visited" src="https://i.imgur.com/8ehwsNR.png" > -->
     </a>
-
+    <p class="convo-break"></p>
+</div>
 
 <!-- show fake footer -->
 <h3 class="anh region">Notes:</h3>
@@ -329,15 +330,14 @@ eventual order for copy paste:
     </div>
 </div>
 </div>
-<br /><br /><br /><br /><br /><br />
-<br /><br /><br /><br /><br /><br />
-<br /><br /><br /><br /><br /><br />
-<br /><br /><br /><br /><br /><br />
-<br /><br /><br /><br /><br /><br />
-<br /><br /><br /><br /><br /><br />
-</div>
 
-
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<!-- </div> -->
 
 <div name="ask-elle" class="ask-elle tab secondary logged-in white-overflow">
 <div class="dm-container">
@@ -533,7 +533,9 @@ eventual order for copy paste:
 </div>
 
 <div class="convo-container">
-    <img class="absolute" src="https://i.giphy.com/media/i2tLw5ZyikSFdkeGHT/giphy.webp" /><a class="cyoa-start-over" href="#start">
+    <img class="absolute" src="https://i.giphy.com/media/i2tLw5ZyikSFdkeGHT/giphy.webp" /><a class="cyoa-start-over start1" href="#start">
+        <span>Start Over =></span>
+    </a> <a class="cyoa-start-over start2" href="#start2">
         <span>Start Over =></span>
     </a>
 </div>
@@ -1004,7 +1006,9 @@ eventual order for copy paste:
 </div>
 
 <div class="convo-container">
-    <img class="absolute" src="https://i.giphy.com/media/i2tLw5ZyikSFdkeGHT/giphy.webp" /><a class="cyoa-start-over" href="#start">
+    <img class="absolute" src="https://i.giphy.com/media/i2tLw5ZyikSFdkeGHT/giphy.webp" /><a class="cyoa-start-over start1" href="#start">
+        <span>Start Over =></span>
+    </a> <a class="cyoa-start-over start2" href="#start2">
         <span>Start Over =></span>
     </a>
 </div>
@@ -1316,7 +1320,9 @@ eventual order for copy paste:
 </div>
 
 <div class="convo-container">
-    <img class="absolute" src="https://i.giphy.com/media/i2tLw5ZyikSFdkeGHT/giphy.webp" /><a class="cyoa-start-over" href="#start">
+    <img class="absolute" src="https://i.giphy.com/media/i2tLw5ZyikSFdkeGHT/giphy.webp" /><a class="cyoa-start-over start1" href="#start">
+        <span>Start Over =></span>
+    </a> <a class="cyoa-start-over start2" href="#start2">
         <span>Start Over =></span>
     </a>
 </div>
@@ -1572,7 +1578,9 @@ eventual order for copy paste:
 
 
 <div class="convo-container">
-    <img class="absolute" src="https://i.giphy.com/media/i2tLw5ZyikSFdkeGHT/giphy.webp" /><a class="cyoa-start-over" href="#start">
+    <img class="absolute" src="https://i.giphy.com/media/i2tLw5ZyikSFdkeGHT/giphy.webp" /><a class="cyoa-start-over start1" href="#start">
+        <span>Start Over =></span>
+    </a> <a class="cyoa-start-over start2" href="#start2">
         <span>Start Over =></span>
     </a>
 </div>
@@ -1779,7 +1787,9 @@ eventual order for copy paste:
 </div>
 
 <div class="convo-container">
-    <img class="absolute" src="https://i.giphy.com/media/i2tLw5ZyikSFdkeGHT/giphy.webp" /><a class="cyoa-start-over" href="#start">
+    <img class="absolute" src="https://i.giphy.com/media/i2tLw5ZyikSFdkeGHT/giphy.webp" /><a class="cyoa-start-over start1" href="#start">
+        <span>Start Over =></span>
+    </a> <a class="cyoa-start-over start2" href="#start2">
         <span>Start Over =></span>
     </a>
 </div>

--- a/Quaranteens/quarantine-6v3.html
+++ b/Quaranteens/quarantine-6v3.html
@@ -1,0 +1,2190 @@
+<link href="../CSS/uploaded-to-ao3-v7.css" rel="stylesheet" />
+<link href="../CSS/uploaded-to-ao3-v7_2.css" rel="stylesheet" />
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery-3.6.0.slim.min.js" integrity="sha256-u7e5khyithlIdTpu22PHhENmPcRdFiHRjhAuHcs05RI=" crossorigin="anonymous"></script>
+
+<script type="text/javascript">
+    function setupAccordion() {
+        $(".expandable").each(function() {
+            var pane = $(this);
+            if (!pane.hasClass("hidden")) {
+                pane.addClass("hidden");
+            }
+            ;pane.prev().removeClass("hidden").addClass("collapsed").click(function(e) {
+                var expander = $(this);
+                if (expander.attr('href') == '#') {
+                    e.preventDefault();
+                }
+                ;expander.toggleClass("collapsed").toggleClass("expanded").next().toggleClass("hidden");
+            });
+        });
+    }
+
+    document.addEventListener("DOMContentLoaded", function() {
+        setupAccordion();
+    });
+</script> 
+
+<!-- 
+eventual order for copy paste: 
+- dummy first tag
+- start
+- start2
+- ask-elle
+- ask-sam
+- ask-jazz
+- ask-tucker
+- ask-none
+- vent
+- root default-tab
+ -->
+
+<figure>
+<a id="tab0" name="tab0"></a>
+<div name="tab0" class="tab0 tab secondary logged-in white-overflow">
+    yo we got a hacker here?
+    <a href="#root">start over</a>
+</div>
+
+<a id="start" name="start"></a>
+<a id="start2" name="start2"></a>
+<a id="root" name="root"></a>
+<a id="ask-elle" name="ask-elle"></a>
+<a id="ask-sam" name="ask-sam"></a>
+<a id="ask-jazz" name="ask-jazz"></a>
+<a id="ask-tucker" name="ask-tucker"></a>
+<a id="ask-none" name="ask-none"></a>
+<a id="vent" name="vent"></a>
+
+<div class="root default-tab secondary logged-in white-overflow">
+
+<div class="rootTabStuff">
+<div class="convo-container room">
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/9D0wLKQ.png" height="auto" /></p>
+        <p><span class="dia-thinking thinking-small white"> (Okay, it's been a few days since the first dose of that ghost vaccine.)</span></p>
+    </div>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/6IOqihj.png" height="auto" /></p>
+        <p><span class="dia-thinking thinking-small white"> (Frostbite thought I'd get a mild fever, but it wasn't that bad.)</span></p>
+    </div>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/sWzvD4D.png" height="auto" /></p>
+        <p><span class="dia-thinking thinking-small white"> (And I feel better now. So today's the day!)</span></p>
+    </div>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/mpSroxY.png" height="auto" /></p>
+        <p><span class="dia white"> I'm finally gonna tell Mom and Dad that I'm half ghost and,...</span></p>
+    </div>
+    <p class="convo-break"></p>
+<!-- </div>
+--
+<div class="convo-container"> -->
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/J12HKH5.png" height="auto" /></p>
+        <p><span class="dia white"> I'm just- </span></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/CF0bJOg.png" height="auto" /></p>
+        <p><span class="dia white"> -really nervous</span></p>
+    </div>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/ndTF5M5.png" height="auto" /></p>
+        <p><span class="dia-thinking thinking-small white"> (Deep breaths, deep breaths) </span></p>
+    </div>
+    <!-- <div class="tall tall-fadeout"></div> -->
+</div>
+<br /><br /><br /><br />
+<br /><br /><br /><br />
+
+<div class="convo-container">
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/PBWGXV2.png" height="auto" /></p>
+        <p><span class="dia-thinking thinking-small white"> (Okay.)</span></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/NJVbWtF.png" height="auto" /></p>
+        <p><span class="dia-thinking thinking-small white"> (It'll be okay.)</span></p>
+    </div>
+
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/TZVxzXS.png" height="auto" /></p>
+        <p><span class="dia white"> I hope I dont mess it up</span></p>
+    </div>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/SdZXScA.png" height="auto" /></p>
+        <p><span class="dia white"> Worst case scenario I guess I could ask Clockwork's help to undo it?</span></p>
+    </div>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/BDlGgi9.png" height="auto" /></p>
+        <p><span class="dia white"> Hopefully I won't have to.</span></p>
+    </div>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/8ZlDMMv.png" height="auto" /></p>
+        <p><span class="dia-thinking thinking-small white"> (Okay, but before I go...)</span></p>
+    </div>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/ReWdgDT.png" height="auto" /></p>
+        <p><span class="dia-thinking thinking-small white"> (Maybe I should... ask someone for advice?)</span></p>
+    </div>
+</div>
+</div>
+
+<div class="startTabStuff">
+<div class="convo-container">
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/J12HKH5.png" height="auto" /></p>
+        <p><span class="dia white">Phew, that was rough!</span></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/dhU1LQC.png" height="auto" /></p>
+        <p><span class="dia white">That didn't go how I expected. </span></p>
+    </div><p class="convo-break"></p>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/SdZXScA.png" height="auto" /></p>
+        <p><span class="dia white"> Maybe I should try something different this time. </span></p>
+    </div><p class="convo-break"></p>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/yE409k4.png" height="auto" /></p>
+        <p><span class="dia-thinking thinking-small white"> What should I do?</span></p>
+    </div>
+</div>
+</div>
+
+<div class="start2TabStuff">
+<div class="convo-container">
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/J12HKH5.png" height="auto" /></p>
+        <p><span class="dia white">Phew, that was rough!</span></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/dhU1LQC.png" height="auto" /></p>
+        <p><span class="dia white">That didn't go how I - </span></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/lzURIKM.png" height="auto" /></p>
+        <p><span class="dia white"> ... </span></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/SdZXScA.png" height="auto" /></p>
+        <p><span class="dia white"> Wait.  </span></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/BXJK9Pk.png" height="auto" /></p>
+        <p><span class="dia white"> I've tried everything I can think of! </span></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/TZVxzXS.png" height="auto" /></p>
+        <p><span class="dia white"> And somehow, none of them worked?? </span></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/CF0bJOg.png" height="auto" /></p>
+        <p><span class="dia white"> I can't quit now! But- </span></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/u0m8t9c.png" height="auto" /></p>
+        <p><span class="dia white"> What else can I do? I- </span></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/kt9Q4xF.png" height="auto" /></p>
+        <p><span class="dia white"> This is so??? Frustrating??? </span></p>
+    </div>
+    <p class="convo-break"></p>
+</div>   
+</div>
+
+<!-- show 4 + 1 + 1 options -->
+<div class="convo-container tall choices">
+    <p class="convo-break"></p>
+    <a class="cyoa-choice-5 collapsed" href="#ask-jazz">
+        <span class="">Ask Jazz =></span> 
+        <!-- <img class="cyoa-visited" src="https://i.imgur.com/8ehwsNR.png" > -->
+    </a> <a class="cyoa-choice-5 expandable" href="#ask-jazz">
+        <span class="">Ask Jazz =></span> 
+        <img class="cyoa-visited" src="https://i.imgur.com/8ehwsNR.png" >
+    </a> <a class="cyoa-choice-5 collapsed" href="#ask-sam">
+        <span class="">Ask Sam =></span>  
+        <!-- <img class="cyoa-visited" src="https://i.imgur.com/8ehwsNR.png" > -->
+    </a> <a class="cyoa-choice-5 expandable" href="#ask-sam">
+        <span class="">Ask Sam =></span>  
+        <img class="cyoa-visited" src="https://i.imgur.com/8ehwsNR.png" >
+    </a> 
+    <br /><br />
+    <a class="cyoa-choice-5 collapsed" href="#ask-tucker">
+        <span class="">Ask Tucker =></span> 
+        <!-- <img class="cyoa-visited" src="https://i.imgur.com/8ehwsNR.png" > -->
+    </a> <a class="cyoa-choice-5 expandable" href="#ask-tucker">
+        <span class="">Ask Tucker =></span> 
+        <img class="cyoa-visited" src="https://i.imgur.com/8ehwsNR.png" >
+    </a>  <a class="cyoa-choice-5 collapsed" href="#ask-elle">
+        <span class="">Ask Elle =></span> 
+        <!-- <img class="cyoa-visited" src="https://i.imgur.com/8ehwsNR.png" > -->
+    </a> <a class="cyoa-choice-5 expandable" href="#ask-elle">
+        <span class="">Ask Elle =></span> 
+        <img class="cyoa-visited" src="https://i.imgur.com/8ehwsNR.png" >
+    </a> 
+    <br /><br />
+    <a class="cyoa-choice-5 collapsed askNoneBtn" href="#ask-none">
+        <span class="">Ask no one =></span>
+        <!-- <img class="cyoa-visited" src="https://progress-tracker.mystyrust.repl.co/images/ask-none/visited.png" > -->
+    </a> <a class="cyoa-choice-5 expandable" href="#ask-none">
+        <span class="">Ask no one =></span>
+        <img class="cyoa-visited" src="https://i.imgur.com/8ehwsNR.png" >
+    </a>
+    <a class="cyoa-choice-5 ventBtn" href="#vent">
+        <span class="">Vent =></span>
+        <!-- <img class="cyoa-visited" src="https://i.imgur.com/8ehwsNR.png" > -->
+    </a>
+
+
+<!-- show fake footer -->
+<h3 class="anh region">Notes:</h3>
+<p class="fakenotes region rootTabStuff">Which was your favorite route? Thanks for reading!</p>
+<p class="fakenotes region startTabStuff">Which was your favorite route? Thanks for reading!</p>
+<p class="fakenotes region start2TabStuff">How many times can I embarass Danny in an identity reveal scenario? At least 5.</p>
+<p class="bline actions">
+    <a class="button-end"><span class="topb">
+        ↑ Top
+        <img src="https://i.imgur.com/RJmQlzw.png" />
+    </span></a>
+    <a class="button-end"><span class="kudosb">
+        Kudos ♥ 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+    <a class="button-end"><span class="collectionb">
+        Add to Collections 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+    <a class="button-end"><span class="bookmarkb">
+        Bookmark 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+    <a class="button-end"><span class="commentsb">
+        Comments (2) 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+</p>
+<p class="convo-break"></p>
+<!-- show cw warning the readers lol -->
+<div class="convo-container tall rootTabStuff">
+    <div class="convo-right">
+        <p><span class="dia white ">Oh hello there! Trying to skip to the end?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right convo-hidden">
+        <p><span class="dia white">You'll have to finish reading first.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right convo-hidden">
+        <p><span class="dia white">Click one of the routes to go <br/>through the story.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right convo-hidden">
+        <p><span class="dia white">Hold your applause until the end!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+</div>
+<div class="convo-container tall startTabStuff">
+    <div class="convo-right">
+        <p><span class="dia white"> No the story isn't done yet, <del>I'm not</del> sorry.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right convo-hidden">
+        <p><span class="dia white">Which one is the true ending?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right convo-hidden">
+        <p><span class="dia white">Click one of the routes to go <br/>through the story.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+</div>
+<div class="convo-container tall start2TabStuff">
+    <div class="convo-right">
+        <p><span class="dia white">Wait that route is new. Is this the home stretch?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right convo-hidden">
+        <p><span class="dia white">Author, I'm sure you could embarass Danny <br/>even more times if you tried hard enough.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right convo-hidden">
+        <p><span class="dia white">Also why does this fic only have 2 comments? <br/>Readers, you need to fix that!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+</div>
+</div>
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+</div>
+
+
+
+<div name="ask-elle" class="ask-elle tab secondary logged-in white-overflow">
+<div class="dm-container">
+    <p class="dm-contact"> 
+        <img class="dm-icon" src ="https://i.imgur.com/3Wci28o.png" />
+        <span class="dm-username">elle phantom</span> <br />
+        <span class="dm-handle">@elleventeen</span> 
+    </p>
+    <p class="dm-block">
+        <span class="dm-right-init"> hey elle so im planning to tell mom and dad the big news today</span>
+        <span class="dm-right"> you know the news that im a half ghost</span>
+        <span class="tw-time-right">2:15 pm <span class="tw-check"> ✓ </span></span>
+        
+        <span class="dm-left-init"> omg </span>
+        <span class="dm-left"> good luck!</span>
+        <span class="tw-time-left">2:20 pm</span>
+        <span><img class="dm-chat-icon" src ="https://i.imgur.com/3Wci28o.png" /></span>
+        
+        <span class="dm-right-init"> actually i was wondering if you had any last minute advice 👉👈</span>
+        <span class="tw-time-right">2:22 pm <span class="tw-check"> ✓ </span></span>
+
+        <span class="dm-left-init"> so ur not ready, is what im hearing</span>
+        <span class="tw-time-left">2:25 pm</span>
+        <span><img class="dm-chat-icon" src ="https://i.imgur.com/3Wci28o.png" /></span>
+        
+        <span class="dm-right-init"> i am too ready. i just</span>
+        <span class="dm-right"> dont have a solid plan.</span>
+        <span class="dm-right"> i need ideas</span>
+        <span class="tw-time-right">2:27 pm <span class="tw-check"> ✓ </span></span>
+    
+        <span class="dm-left-init"> ive never done something like this before. vlad always knew and valerie found out. </span>
+        <span class="dm-left"> oh! she found out bc she caught me eating food when we met. </span>
+        <span class="dm-left"> well, stealing food. and then i saved her from a collapsing building.</span>
+        <span class="dm-left"> she saw me transform when i saved her</span>
+        <span class="tw-time-left">2:34 pm</span>
+        <span><img class="dm-chat-icon" src ="https://i.imgur.com/3Wci28o.png" /></span>
+    
+        <span class="dm-right-init"> oh wow</span>
+        <span class="dm-right"> i dont want like... life or death to force my secret out. i want to tell them of my own free will you know</span>
+        <span class="dm-right"> so i dont think ill collapse a building any time soon </span>
+        <span class="dm-right"> thanks for sharing that thou. i had no idea thats how you and valerie met</span>
+        <span class="tw-time-right">2:37 pm <span class="tw-check"> ✓ </span></span>
+    
+        <span class="dm-left-init"> what i mean to say is</span>
+        <span class="dm-left"> she saw me as human. a ghost who was a little human. </span>
+        <span class="dm-left"> prob bc of the fact that i needed food</span>
+        <span class="dm-left"> so try something like that</span>
+        <span class="dm-left"> show that your a ghost whos human. a "humane" ghost? a ghost with human needs? </span>
+        <span class="tw-time-left">2:42 pm</span>
+        <span><img class="dm-chat-icon" src ="https://i.imgur.com/3Wci28o.png" /></span>
+    
+        <span class="dm-right-init"> hey thats a great idea! thanks!</span>
+        <span class="tw-time-right">2:43 pm <span class="tw-check"> ✓ </span></span>
+        
+        <span class="dm-left-init"> anytime danny </span>
+        <span class="tw-time-left">2:45 pm</span>
+        <span><img class="dm-chat-icon" src ="https://i.imgur.com/3Wci28o.png" /></span>
+    </p>
+</div>
+<div class="dm-container dm-type">
+    <p class="dm-typebox"></p>
+</div>
+
+<br /><br />
+
+<div class="convo-container kitchen">
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/3EsrGVC.png" height="auto" /></p>
+        <p><span class="dia white"> I should have them catch me doing something I'd only do if I was a human! </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/gLzU9bL.png" height="auto" /></p>
+        <p><span class="dia-thinking thinking-small white"> (Mom and dad have always been wanting to study Phantom too, so...) </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/bKtuWGZ.png" height="auto" /></p>
+        <p><span class="dia white"> Alright, what do we hae in the fridge?</span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/YLIBJth.png" height="auto" /></p>
+        <p><span class="dia white"> Not much, huh. </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/3EsrGVC.png" height="auto" /></p>
+        <p><span class="dia white"> There is ice cream in the freezer! Might as well get myself a bowl.</span></p>
+    </div>
+
+    <div class="convo-right">
+        <p><span class="dia white"> Kids, what would you like for dinn- </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/MACHzm7.png" height="auto" /></p>
+    </div>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/cDHa8iW.png" height="auto" /></p>
+        <p><span class="dia white"> ... </span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> Phantom? </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/1YYfREo.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://cdn.discordapp.com/attachments/886029945237823528/906346490639822888/Untitled_Artwork.gif" height="auto" /></p>
+        <p><span class="dia white">...</span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> ... </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/M29yaUj.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right">
+        <p><span class="dia white"> Madds we should get pizz - </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/7U4pVLw.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> Oh boy. Ghost boy. In our kitchen. Eating...</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/bkAnTby.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> My Chocolate Fudge Rocky Road flavored ice cream?!! <em>HOW COULD YOU?!?</em></span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/qTvfGgQ.png" height="auto" /></p>
+    </div>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/3XG8tw3.png" height="auto" /></p>
+        <p><span class="dia white"> ...It tasted good.</span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> Phantom you have good taste, I'll give you that. </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/NMTRVWE.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> I know my kids give you our equipment, so you might not consider that “stealing”.  </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/Pk5wXAw.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> But this? Most definitely is a kind of stealing </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/Pk5wXAw.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/YLIBJth.png" height="auto" /></p>
+        <p><span class="dia white"> But I wanted to -</span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> You could have taken that ice cream and left. Like you do our weapons. </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/1E1Ws11.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/YLIBJth.png" height="auto" /></p>
+        <p><span class="dia white"> - show you that -</span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> I tolerate your use of our Fenton ghost fighting tools.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/1E1Ws11.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> But this isnt your house </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/1E1Ws11.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/axVX8lh.png" height="auto" /></p>
+        <p><span class="dia white"> (but... it is)</span></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right">
+        <p><span class="dia white"> Get. Out.  </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/1E1Ws11.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/axVX8lh.png" height="auto" /></p>
+        <p><span class="dia white"> ...okay...</span></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right">
+        <p><span class="dia white"> Do ghosts like ice cream or something? </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/bkAnTby.png" height="auto" /></p>
+    </div>
+</div>
+
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+
+<div class="convo-container gz2">
+    <div class="convo-right">
+        <p><span class="dia white">She screamed for ice cream, didn't she? </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+     <div class="convo-left">
+         <p><img class="convo-icon" src="https://i.imgur.com/xIvJuAj.png" height="auto" /></p>
+         <p><span class="dia white"> ...in a way, I guess.</span></p>
+    </div>
+</div>
+
+<div class="convo-container">
+    <img class="absolute" src="https://i.giphy.com/media/i2tLw5ZyikSFdkeGHT/giphy.webp" /><a class="cyoa-start-over" href="#start">
+        <span>Start Over =></span>
+    </a>
+</div>
+
+<!-- show fake footer -->
+<h3 class="anh region">Notes:</h3>
+<p class="fakenotes region">Well that didn't go as planned.</p>
+<p class="bline actions">
+    <a class="button-end"><span class="topb">
+        ↑ Top
+        <img src="https://i.imgur.com/RJmQlzw.png" />
+    </span></a>
+    <a class="button-end"><span class="kudosb">
+        Kudos ♥ 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+    <a class="button-end"><span class="collectionb">
+        Add to Collections 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+    <a class="button-end"><span class="bookmarkb">
+        Bookmark 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+    <a class="button-end"><span class="commentsb">
+        Comments (2) 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+</p>
+<p class="convo-break"></p>
+<!-- show cw warning the readers lol -->
+<div class="convo-container tall">
+    <p class="convo-break"></p>
+    <div class="convo-right">
+        <p><span class="dia white">Huh, guess this route wasn't the one.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right">
+        <p><span class="dia white">Really thought this would turn into <br/> a dissection fic for a second there..</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right convo-hidden">
+        <p><span class="dia white">Let's start over.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/jWRyP6Y.png" height="auto" /></p>
+    </div>
+</div>
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+</div>
+
+<div name="ask-sam" class="ask-sam tab secondary logged-in white-overflow">
+<div class="phone">
+    <br>
+    <p class="messagebody">
+        <span class="header">Sam</span><br /><br />
+        
+        <span class="breply">sammmm</span><br />
+        <span class="breply">i need some advice</span><br />
+
+        <span class="text">sure ill try my best</span><br />
+
+        <span class="breply">so i wanna </span><br />
+        <span class="breply">do what i shoudlve from the beginning and finally tell my parents that im phantom</span><br />
+        <span class="breply">any advice on how to not mess up</span><br />
+
+        <span class="text">i somehow feel like the wrong person to ask for this type of advice</span><br />
+
+        <span class="breply">huh? why? you have the brain cell</span><br />
+        <span class="text">i do, but consider my relationship w my parents</span><br />
+        <span class="text">they hate everything i like</span><br />
+
+        <span class="breply">but you also live true to yourself</span><br />
+        <span class="breply">do you think its gotten any better since quarantine?</span><br />
+        <span class="text">honestly i feel like nothings changed</span><br />
+
+        <span class="breply">ohh</span><br />
+        <span class="text">but danny, my circumstances and relationship w my parents is different from yours</span><br />
+        <span class="text">i still think you should try, if you're ready for it</span><br />
+
+        <span class="breply">yeah i do wwant to</span><br />
+        <span class="breply">any advice, for how to tackle it?</span><br />
+        <span class="text">i know! show them that as a human, you're a little bit ghostly</span><br />
+
+        <span class="text">very goth. such emo.</span><br />
+
+        <span class="text">what i mean, show them that you have ghost powers as a human</span><br />
+        <span class="text">and THEN after they adjust to that, tell them that your Phantom</span><br />
+
+        <span class="breply">hey, that's a pretty solid idea, thanks Sam!</span><br />
+
+        <span class="text">good luck danny. let me know what happens.</span><br />
+
+        <span class="breply">yeah i think i am</span><br />
+        <span class="breply">i wanna tell them about elle so- ill have to be</span><br />
+
+        <span class="text">hey dont do this bc of an obligation. or bc you aren't ready.</span><br />
+
+        <span class="breply">ive been procrastinating for a whole year.</span><br />
+        <span class="breply">well technically longer.</span><br />
+        <span class="breply">i just think nows as good a time as any.</span><br />
+        <span class="breply">i never had a good reason to share my secret before, but now i do, i guess.</span><br />
+
+        <span class="text">fair</span><br />
+
+        <span class="breply">i remembered something i read in fanfic thats given me an idea for how to do this</span><br />
+        <span class="breply">show that im a little ghostly as a human, i mean</span><br />
+
+        <span class="text">uhh</span><br />
+        <span class="text">which fic</span><br />
+        <span class="text">fanfic isnt like real life????</span><br />
+    </p>
+</div>
+
+<!-- talking to parents -->
+<div class="convo-container living-room">
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/mpSroxY.png" height="auto" /></p>
+        <p><span class="dia white">So, Mom, Dad - I have a magic act, that I'm working on for the school talent show!</span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white">Oh neato!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/7U4pVLw.png" height="auto" /></p>
+    </div> 
+    <div class="convo-right">
+        <p><span class="dia white">We'd love to see you practice!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/MACHzm7.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/VFIkUBp.png" height="auto" /></p>
+        <p><span class="dia white">I don't have a wand, hat, or cape, but let's pretend I do.</span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white">Don't worry, Danny. Just do your best.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/SmekpQf.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/PBWGXV2.png" height="auto" /></p>
+        <p><span class="dia-thinking thinking-small white">Alright, phew-</span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/BDlGgi9.png" height="auto" /></p>
+        <p><span class="dia white">Welcome to the magic show of the Fantastic Fenton, a human magician 
+            capable of all sorts of feats! His final act will leave everyone speechless! </span></p>
+    </div>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/intfr1d.png" height="auto" /></p>
+        <p><span class="dia white"> For my first act: observe! </span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> A quarter! </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/7U4pVLw.png" height="auto" /> </p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/LUaJ80t.png" height="auto" /></p>
+        <p><span class="dia white"> A simple wave of the hand, and it disappears! </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/Arptb9D.png" height="auto" /></p>
+        <p><span class="dia white"> But if I check behind your ear, I find... a nickel.</span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> Where'd the quarter go?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0f8vOZo.png" height="auto" /> </p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/WoLoNHk.png" height="auto" /></p>
+        <p><span class="dia white"> Check under Mom's hand.</span></p>
+    </div>
+    <div class="convo-right"> 
+        <p><span class="dia white">You're...right! How did you do that danny? Your sleeves are short!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/MACHzm7.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/MqlGS5l.png" height="auto" /></p>
+        <p><span class="dia-thinking thinking-small white"> (Thank you ghost powers)</span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/BDlGgi9.png" height="auto" /></p>
+        <p><span class="dia white"> A magician never reveals their secrets... but I'll make an exception this time. After my final trick. </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/mpSroxY.png" height="auto" /></p>
+        <p><span class="dia white"> For my next trick! I have assembled - an empty water bottle, an egg, and a banana.</span></p>
+    </div>
+    <div class="convo-right"> 
+        <p><span class="dia white">Are you going to fit the objects inside the water bottle, without breaking it?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/MACHzm7.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> Oh I think I saw a trick like this on tiktok!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/7U4pVLw.png" height="auto" /> </p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/mvgXzcG.png" height="auto" /></p>
+        <p><span class="dia white"> You definitely have the right idea Dad. I'll just <em>swoop</em> this egg in, and -</span></p>
+    </div>
+</div>
+
+<div class="img-container img-bottle-container"> 
+    <!-- EGG in bottole -->
+    <img class="img-holder" src="https://i.imgur.com/xwAKktt.png" /> <img class="img-holder img-egg-inside" src="https://i.imgur.com/knMo5ZU.png" /> 
+</div>
+
+<div class="convo-container living-room">
+    <div class="convo-right">
+        <p><span class="dia white"> It's inside the bottle!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/7U4pVLw.png" height="auto" /> </p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/mpSroxY.png" height="auto" /></p>
+        <p><span class="dia white"> And since it's a hardboiled egg, you can swirl the bottle around all you want and the inside of the bottle will stay clean!</span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> Ooh let me try!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/7U4pVLw.png" height="auto" /> </p>
+    </div>
+    <div class="convo-right"> 
+        <p><span class="dia white">...there's no hole? </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/1YYfREo.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> What do you mean?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/Jit8YVn.png" height="auto" /> </p>
+    </div>
+    <div class="convo-right"> 
+        <p><span class="dia white">The way this trick is done is by sticking the egg in through a secret hole on the side of the bottle. 
+             Big enough for the egg, but small enough for the audience to miss.
+        </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/1YYfREo.png" height="auto" /></p>
+    </div>
+       
+    <div class="convo-right"> 
+        <p><span class="dia white">But you let us see and touch the bottle, and there is no hole. </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/cvtsm46.png" height="auto" /></p>
+    </div>
+    <div class="convo-right"> 
+        <p><span class="dia white">Danny, how did you-?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/Pk5wXAw.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/mvgXzcG.png" height="auto" /></p>
+        <p><span class="dia white"> Oh, but the trick isn't over yet, Mom! Here, let me just take that bottle back, I'll <em>swoop</em> that egg out -</span></p>
+    </div>
+</div>
+<!-- empty bottle -->
+<div class="img-container img-bottle-container"> 
+    <!-- EGG -->
+    <img class="img-holder" src="https://i.imgur.com/xwAKktt.png" /> 
+<img class="img-holder img-egg-outside" src="https://i.imgur.com/knMo5ZU.png" /> 
+    <!-- <img class="img-holder" src="https://i.imgur.com/z7BMB2R.png" />  -->
+</div>
+
+<div class="convo-container living-room">
+    <div class="convo-right"> 
+        <p><span class="dia white">..!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/Vu4DJIK.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> Did you just take the egg out from the bottom of the bottle?! Did your hand just go <em>through</em> the bottle??</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/bkAnTby.png" height="auto" /> </p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/intfr1d.png" height="auto" /></p>
+        <p><span class="dia white"> - and stick in this large banana. The water bottle's opening looks too small.</span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/mvgXzcG.png" height="auto" /></p>
+        <p><span class="dia white"> But this clear plastic bottle is big enough to hold the banana anyway! </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/cFSZxST.png" height="auto" /></p>
+        <p><span class="dia white"> We can solve that by turning the banana intangible, no big deal.  </span></p>
+    </div>
+</div>
+<!-- banna na in bottle  -->
+<div class="img-container img-bottle-container"> 
+    <img class="img-holder" src="https://i.imgur.com/xwAKktt.png" /> <img class="img-holder img-banana-inside" src="https://i.imgur.com/z7BMB2R.png" /> 
+</div>
+
+<div class="convo-container living-room">
+    <div class="convo-right">
+        <p><span class="dia white"> How did you -?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0f8vOZo.png" height="auto" /> </p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right">
+        <p><span class="dia white"> Danny is this -?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/goGmH20.png" height="auto" /></p>
+    </div>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/TZVxzXS.png" height="auto" /></p>
+        <p><span class="dia white"> I'll explain, after this final trick. I promise.</span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/Arptb9D.png" height="auto" /></p>
+        <p><span class="dia white"> In my hand I have a knife. </span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> Be careful!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/NMTRVWE.png" height="auto" /> </p>
+    </div>
+    <div class="convo-right"> 
+        <p><span class="dia white">Danny, that better be a trick knife!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/Pk5wXAw.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/cFSZxST.png" height="auto" /></p>
+        <p><span class="dia white"> First, let me take that banana out of the water bottle.</span></p>
+    </div>
+</div>
+<!-- banna na out of  bottle  -->
+<div class="img-container img-bottle-container"> 
+    <!--   BANANAN out of bottole -->
+    <img class="img-holder" src="https://i.imgur.com/xwAKktt.png" /> 
+    <img class="img-holder img-banana-outside" src="https://i.imgur.com/z7BMB2R.png" /> 
+</div>
+
+<div class="convo-container living-room">    
+    <div class="convo-right">
+        <p><span class="dia white"> ..! </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/NMTRVWE.png" height="auto" /> </p>
+    </div>
+    <div class="convo-right"> 
+        <p><span class="dia white">...phased it? It went through the bottle again...</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/goGmH20.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/intfr1d.png" height="auto" /></p>
+        <p><span class="dia white"> And cut a few slices of the banana off. </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/mvgXzcG.png" height="auto" /></p>
+        <p><span class="dia white"> But if I cut them thinner we can use this banana to make banana chips!</span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/intfr1d.png" height="auto" /></p>
+        <p><span class="dia white"> So I'll cut it thinner and thinner, and -</span></p>
+    </div>
+</div>
+
+<div class="img-container"> 
+    <img class="img-holder img-knife-pos" src="https://i.imgur.com/r9hJlny.png" /> 
+    <img class="img-holder" src="https://i.imgur.com/2LfxHCb.png" /> 
+    <!-- chopping banana slices -->
+</div>
+
+<div class="convo-container living-room">    
+    <div class="convo-right">
+        <p><span class="dia white"> Watch your hand!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/NMTRVWE.png" height="auto" /> </p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right"> 
+        <p><span class="dia white">Danny!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/goGmH20.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <!-- icon should have green eyed danny here -->
+        <p><img class="convo-icon" src="https://i.imgur.com/c44nZUo.png" height="auto" /></p>
+        <p><span class="dia white"> Oh, the knife went right through my hand, what do you know? </span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> Danny <em>what type of magic show -</em> </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/NMTRVWE.png" height="auto" /> </p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> Wait! Your eyes!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/mo6UaK3.png" height="auto" /> </p>
+    </div>
+    <div class="convo-right"> 
+        <p><span class="dia white">What type of ghost are you working with?!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/qTvfGgQ.png" height="auto" /></p>
+    </div>
+    <div class="convo-right"> 
+        <p><span class="dia white">Drop that knife before I take it away from you myself!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/1E1Ws11.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/Arptb9D.png" height="auto" /></p>
+        <p><span class="dia white"> Mom! Dad! </span></p>
+    </div>
+    <div class="convo-right">
+       <p><span class="dia white"> That would explain the coin trick too. 
+           It really WAS invisible. So you wouldn't need long sleeves.</span></p>
+       <p><img class="convo-icon" src="https://i.imgur.com/0f8vOZo.png" height="auto" /> </p>
+    </div>
+    <div class="convo-right"> 
+        <p><span class="dia white">Danny let go!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/1E1Ws11.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/jG5yYJs.png" height="auto" /></p>
+        <p><span class="dia white"> Mom stop that's a real knife! Careful! Ouch!</span></p>
+    </div>
+    <div class="convo-right"> 
+        <p><span class="dia white">Leave my son alone. Get out of his body!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/1E1Ws11.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/a8wCXEU.png" height="auto" /></p>
+        <p><span class="dia white"> Mom, what?</span></p>
+    </div>
+    <div class="convo-right"> 
+        <p><span class="dia white">I'm sorry, Danny. I'll bandage your hand as soon as the ghost leaves. </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/goGmH20.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/BXJK9Pk.png" height="auto" /></p>
+        <p><span class="dia white"> What are you-?</span></p>
+    </div>
+    <div class="convo-right"> 
+        <p><span class="dia white">Your eyes. They changed color and glowed when the ghost possessed you.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/Pk5wXAw.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/kt9Q4xF.png" height="auto" /></p>
+        <p><span class="dia white"> I'm not possessed! </span></p>
+    </div>
+    <div class="convo-right"> 
+        <p><span class="dia white">That's what they all say!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/1E1Ws11.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> Whatever ghost you're working with, Danny, it can't be good. </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/6LqnTw8.png" height="auto" /> </p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> You can't count on him to save you from every time you might cut your finger off.
+            It might cut your finger off on purpose, next time.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/qTvfGgQ.png" height="auto" /> </p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/PSY7lYI.png" height="auto" /></p>
+        <p><span class="dia white"> That's not what's happening!</span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> I'll get the -</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/maaaZMe.png" height="auto" /> </p>
+    </div>
+    <div class="convo-left">
+        <!-- green eyed danny again? lols -->
+        <p><img class="convo-icon" src="https://i.imgur.com/u0m8t9c.png" height="auto" /></p>
+        <p><span class="dia white"> No need, I'll just be on my way out.</span></p>
+    </div>
+</div>
+
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+
+<!-- <p class="convo-pad"></p> -->
+<div class="convo-container gz2">
+    <div class="convo-right">
+        <p><span class="dia white">Oh, it's knife to meet you, Danny!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/YLIBJth.png" height="auto" /></p>
+        <p><span class="dia white">It was a better idea in my head! I swear!</span></p>
+    </div> 
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/Fr3ryh8.png" height="auto" /></p>
+        <p><span class="dia white">And it was such a good fic too!</span></p>
+    </div> 
+</div>
+
+<div class="convo-container">
+    <img class="absolute" src="https://i.giphy.com/media/i2tLw5ZyikSFdkeGHT/giphy.webp" /><a class="cyoa-start-over" href="#start">
+        <span>Start Over =></span>
+    </a>
+</div>
+
+<!-- show fake footer -->
+<h3 class="anh region">Notes:</h3>
+<p class="fakenotes region">Ah yes, you're regularly scheduled angst, as promised.</p>
+<p class="bline actions">
+    <a class="button-end"><span class="topb">
+        ↑ Top
+        <img src="https://i.imgur.com/RJmQlzw.png" />
+    </span></a>
+    <a class="button-end"><span class="kudosb">
+        Kudos ♥ 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+    <a class="button-end"><span class="collectionb">
+        Add to Collections 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+    <a class="button-end"><span class="bookmarkb">
+        Bookmark 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+    <a class="button-end"><span class="commentsb">
+        Comments (2) 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+</p>
+<p class="convo-break"></p>
+<!-- show cw warning the readers lol -->
+<div class="convo-container tall">
+    <div class="convo-right">
+        <p><span class="dia white ">*your</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right">
+        <p><span class="dia white">Sam knew what she was talking about when she said fanfic isn't like real life.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/jWRyP6Y.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right convo-hidden">
+        <p><span class="dia white">Are you really gonna trust a fanfic written by "gothic_manslayer"?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right convo-hidden">
+        <p><span class="dia white">Is this fic even tagged as angst? ...let's start over.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+</div>
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+</div>
+
+<div name="ask-jazz" class="ask-jazz tab secondary logged-in white-overflow">
+<div class="phone">
+    <br>
+    <p class="messagebody">
+        <span class="header">Jazz the Spazz</span><br /><br />
+        
+        <span class="breply">jazz</span><br />
+        <span class="breply">i have a question</span><br />
+
+        <span class="text">whatsup</span><br />
+
+        <span class="breply">hypothetically if i were to tell mom and dad i was a half gohst</span><br />
+        <span class="breply">how do you think i should go about it</span><br />
+        <span class="breply">hypothetically</span><br />
+
+        <span class="text">omg danny are you gonna do it???</span><br />
+
+        <span class="breply">hypothetically</span><br />
+        <span class="text">also im literally upstairs you can just come up to my room to ask</span><br />
+
+        <span class="breply">but also its been a whole year since quarantine started.</span><br />
+        <span class="breply">and its sTILL a secret</span><br />
+        <span class="breply">i mean ive always wanted to tell them</span><br />
+        <span class="breply">so... yeah</span><br />
+
+        <span class="text">hey just bc its been a whole year, doesnt mean you have to tell them</span><br />
+        <span class="text">but if that is what you want to do, then i got your back </span><br />
+        <span class="text">do you want me there when you tell them?</span><br />
+
+        <span class="breply">no, i wanna do this myself.</span><br />
+        <span class="breply">i feel like i have to.</span><br />
+        <span class="text">dont feel like you have to do anything</span><br />
+
+        <span class="breply">but what i wanted to ask was</span><br />
+        <span class="breply">any tips???</span><br />
+
+        <span class="text">okay so its true mom and dad havent been as anti phantom as they used to be</span><br />
+        <span class="text">but you still have to take it slow</span><br />
+        <span class="text">maybe instead of talking about ghosts specifically</span><br />
+        <span class="text">talk to them about yourself a little</span><br />
+        <span class="text">then when the conversation seems to be going smoothly, you can tell them</span><br />
+
+        <span class="breply">okay</span><br />
+        <span class="breply">makes sense</span><br />
+        <span class="breply">that gives me an idea</span><br />
+        <span class="breply">thanks jazz</span><br />
+    </p>
+</div>
+
+<div class="convo-container living-room">
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/J12HKH5.png" height="auto" /></p>
+        <p><span class="dia white">Hey Mom, hey Dad, I -</span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/c8ZxyPL.png" height="auto" /></p>
+        <p><span class="dia white">I have something really important to tell you but-</span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/mpSroxY.png" height="auto" /></p>
+        <p><span class="dia white">-before I do that I thought we could play a game.</span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white">A game? I love games!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/7U4pVLw.png" height="auto" /></p>
+    </div> 
+    <div class="convo-right">
+        <p><span class="dia white">We're all ears, Danny.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/MACHzm7.png" height="auto" /></p>
+    </div>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/PBWGXV2.png" height="auto" /></p>
+        <p><span class="dia-thinking thinking-small white">(Okay, Jazz has used this before, so I should give it a try, too.)</span></p>
+    </div>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/i9N6woM.png" height="auto" /></p>
+        <p><span class="dia white">2 truths and a lie!</span></p>
+    </div>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/TZVxzXS.png" height="auto" /></p>
+        <p><span class="dia white">1: I don't like eating toast for breakfast.</span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/SdZXScA.png" height="auto" /></p>
+        <p><span class="dia white">2: I got a C in my last English test</span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/c8ZxyPL.png" height="auto" /></p>
+        <p><span class="dia white">3: I have someone I want you to meet.</span></p>
+    </div>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/mpSroxY.png" height="auto" /></p>
+        <p><span class="dia white">So, which one do you think is the lie?</span></p>
+    </div>
+
+    <div class="convo-right">
+        <p><span class="dia white">Definitely the toast one! The Jack Fenton Toast-O-Meter makes the best toast ever!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/7U4pVLw.png" height="auto" /></p>
+    </div> 
+
+    <div class="convo-right">
+        <p><span class="dia white">Jazz was helping you study for English, so that one has to be true...</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/GHGPGFz.png" height="auto" /></p>
+    </div>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/i9N6woM.png" height="auto" /></p>
+        <p><span class="dia white">Um, actually. That's the lie. I got an B in my last English test!</span></p>
+    </div>
+
+    <div class="convo-right">
+        <p><span class="dia white">Oh congra-</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/MACHzm7.png" height="auto" /></p>
+    </div>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/5UWh1ug.png" height="auto" /></p>
+        <p><span class="dia white">After failing 3 tests in a row I mean, but hey, it's all in the past!</span></p>
+    </div>
+
+    <div class="convo-right">
+        <p><span class="dia white">Oh Danny...</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/goGmH20.png" height="auto" /></p>
+    </div>
+
+    <p class="convo-break"></p>
+
+    <div class="convo-right">
+        <p><span class="dia white">Attaboy, Son!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/7U4pVLw.png" height="auto" /></p>
+    </div> 
+
+    <div class="convo-right">
+        <p><span class="dia white">Wait! This means you don't like Fenton toast?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0f8vOZo.png" height="auto" /></p>
+    </div> 
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/VFIkUBp.png" height="auto" /></p>
+        <p><span class="dia white">Well,... it's good but it gets boring after eating it everyday and-</span></p>
+    </div>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/a8wCXEU.png" height="auto" /></p>
+        <p><span class="dia white">My last statement - I want you both to meet someone! That's true too!</span></p>
+    </div>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/BDlGgi9.png" height="auto" /></p>
+        <p><span class="dia white">I actually want you to meet...Phantom.</span></p>
+    </div>
+
+    <div class="convo-right">
+        <p><span class="dia white">!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/9r9GeL3.png" height="auto" /></p>
+    </div> 
+    <p class="convo-break"></p>
+
+    <div class="convo-right">
+        <p><span class="dia white">!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/Vu4DJIK.png" height="auto" /></p>
+    </div>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/SdZXScA.png" height="auto" /></p>
+        <p><span class="dia white">It can be hard to talk to you guys about some stuff. Ghost stuff. </span></p>
+    </div>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/dhU1LQC.png" height="auto" /></p>
+        <p><span class="dia white">And I'm sorry I waited so long to tell you about this.</span></p>
+    </div>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/J12HKH5.png" height="auto" /></p>
+        <p><span class="dia white">I know you have your differences, and you just tolerate Phantom now, 
+            but he - how do I say this?</span></p>
+    </div>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/mpSroxY.png" height="auto" /></p>
+        <p><span class="dia white">He puts the "fun" in "funeral"!</span></p>
+    </div>
+    <p class="convo-break"></p>
+
+    <div class="convo-right">
+        <p><span class="dia white">...</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/9r9GeL3.png" height="auto" /></p>
+    </div> 
+    <p class="convo-break"></p>
+
+    <div class="convo-right">
+        <p><span class="dia white">...</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/M29yaUj.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/Tm7dceH.png" height="auto" /></p>
+        <p><span class="dia white">Okay I'll just -</span></p>
+    </div>
+
+    <!-- <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/BDlGgi9.png" height="auto" /></p>
+        <p><span class="dia white">Transform behind and come back and explain everything and -</span></p>
+    </div> -->
+
+    <div class="convo-right">
+        <p><span class="dia white">Danny are you...dating the ghost boy?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/Pk5wXAw.png" height="auto" /></p>
+    </div>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/a8wCXEU.png" height="auto" /></p>
+        <p><span class="dia white">Uh, well, actually -</span></p>
+    </div>
+
+    <div class="convo-right">
+        <p><span class="dia white">Oh, that is a lot to take in. I can see why you chose to tell us like this.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0f8vOZo.png" height="auto" /></p>
+    </div> 
+    
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/6IOqihj.png" height="auto" /></p>
+        <p><span class="dia white">...</span></p>
+    </div>
+
+    <div class="convo-right">
+        <p><span class="dia white">Is THAT why you've been failing English?!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/1E1Ws11.png" height="auto" /></p>
+    </div>
+</div>
+
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<div class="convo-container gz2">
+    <div class="convo-right">
+        <p><span class="dia white">I'm sorry, did your parents not approve?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/Fr3ryh8.png" height="auto" /></p>
+        <p><span class="dia white">Not for the reasons I thought they would.</span></p>
+    </div> 
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/YLIBJth.png" height="auto" /></p>
+        <p><span class="dia white">Let me just...try that again. Differently.</span></p>
+    </div> 
+</div>
+
+<div class="convo-container">
+    <img class="absolute" src="https://i.giphy.com/media/i2tLw5ZyikSFdkeGHT/giphy.webp" /><a class="cyoa-start-over" href="#start">
+        <span>Start Over =></span>
+    </a>
+</div>
+
+<!-- show fake footer -->
+<h3 class="anh region">Notes:</h3>
+<p class="fakenotes region">Danny you had 1 job.</p>
+<p class="bline actions">
+    <a class="button-end"><span class="topb">
+        ↑ Top
+        <img src="https://i.imgur.com/RJmQlzw.png" />
+    </span></a>
+    <a class="button-end"><span class="kudosb">
+        Kudos ♥ 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+    <a class="button-end"><span class="collectionb">
+        Add to Collections 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+    <a class="button-end"><span class="bookmarkb">
+        Bookmark 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+    <a class="button-end"><span class="commentsb">
+        Comments (2) 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+</p>
+<p class="convo-break"></p>
+<!-- show cw warning the readers lol -->
+<div class="convo-container tall">
+    <p class="convo-break"></p>
+    <div class="convo-right">
+        <p><span class="dia white">Danny, you just needed to say 1 thing 2 your parents. 3 words. 4 this to be over.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right convo-hidden">
+        <p><span class="dia white">Clearly you did not understand the assignment</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/o37c8XC.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right convo-hidden">
+        <p><span class="dia white">Let's start over.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+</div>
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+</div>
+
+<div name="ask-tucker" class="ask-tucker tab secondary logged-in white-overflow">
+<div class="phone">
+    <br>
+    <p class="messagebody">
+        <span class="header">Tucker</span><br /><br />
+        
+        <span class="breply">hey tuck</span><br />
+        <span class="breply">i need another opinion</span><br />
+
+        <span class="text">are you writing fanfic</span><br />
+
+        <span class="breply">no not yet</span><br />
+        <span class="breply">but i wanna ask a different question</span><br />
+        <span class="breply">a serious question</span><br />
+
+        <span class="text">oh wow, almost perfect grammar. this must be serious.</span><br />
+
+        <span class="breply">how should i break the news to my parents that im half ghost</span><br />
+        <span class="breply">if it were you how would you do it?</span><br />
+        <span class="breply">cuz i dont want them to... freak out you know</span><br />
+
+        <span class="text">oh man thats hard</span><br />
+        <span class="text">wait i do have an idea</span><br />
+
+        <span class="breply">oh? tell</span><br />
+        <span class="text">you know how your parents inventions always wig out near you</span><br />
+        <span class="text">use that as a starting point</span><br />
+
+        <span class="text">tell your parents you know why the inventions target you</span><br />
+        <span class="text">and then...you know...demonstrate</span><br />
+
+        <span class="breply">use technology to start my story for me huh? </span><br />
+        <span class="breply">what if they misunderstand</span><br />
+        
+        <span class="text">then backpedal and claim ectocontamination</span><br />
+        <span class="text">since your parents are scientists, theyll accept scientific evidence</span><br />
+    
+        <span class="text">you just have give them enough evidence to favor your conclusion</span><br />
+
+        <span class="breply">that..</span><br />
+        <span class="breply">sounds like a good idea, actually </span><br />
+        <span class="breply">thanks tuck! </span><br />
+        <span class="text"> no prob friend, lemme know how it goes!</span><br />
+    </p>
+</div>
+<br/> <br/>
+
+<div class="convo-container lab">
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/a8wCXEU.png" height="auto" /></p>
+        <p><span class="dia white">Hey Mom! Hey Dad!</span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/BDlGgi9.png" height="auto" /></p>
+        <p><span class="dia white">Sweet, You're already in the lab!</span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white">Hey Danny! Needed something down here?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/7U4pVLw.png" height="auto" /></p>
+    </div> 
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/Tm7dceH.png" height="auto" /></p>
+        <p><span class="dia white"> Yeah! You know how a lot of your ghost weapons malfunction around me, or target me? </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/LUaJ80t.png" height="auto" /></p>
+        <p><span class="dia white"> I might know why, and I wanted to explain it to you both</span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> Oh?</span>
+        <p><img class="convo-icon" src="https://i.imgur.com/1YYfREo.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/c8ZxyPL.png" height="auto" /></p>
+        <p><span class="dia white"> Yeah, let me show you with one of your tracking devices.</span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/SdZXScA.png" height="auto" /></p>
+        <p><span class="dia white"> Do you have the Fenton Boo-merang around? </span></p>
+    </div>
+    
+    <div class="convo-right">
+        <p><span class="dia white"> We dismantled a while ago, to try to fix it and salvage it for parts actually.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0f8vOZo.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> Our working theory was that it registered a lot of ectoplasmic contamination and returned a false positive sometimes.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/MACHzm7.png" height="auto" /></p>
+    </div>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/Arptb9D.png" height="auto" /></p>
+        <p><span class="dia white"> Well, do you have any other inventions that you were planning to take apart? </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/mvgXzcG.png" height="auto" /></p>
+        <p><span class="dia white"> Could try one of those.</span></p>
+    </div>
+
+    <div class="convo-right">
+        <p><span class="dia white"> Well, there is the Fenton Bearer - never did get that one working. </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/mo6UaK3.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> It should be all the way in the back, Danny.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/cvtsm46.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/BDlGgi9.png" height="auto" /></p>
+        <p><span class="dia white"> Got it, thanks!</span></p>
+    </div>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/SdZXScA.png" height="auto" /></p>
+        <p><span class="dia white"> Yeah I've never seen this one before. What does it do, turn a ghost into a bear?</span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> No, I spelled the word 'bare' wrong on it. It's supposed to-</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0f8vOZo.png" height="auto" /></p>
+    </div>
+</div>
+<div class="img-container">
+    <img class="img-holder" src="https://i.imgur.com/wltxnXy.png?1" />
+</div>
+<div class="convo-container lab">
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/EF93iZr.png" height="auto" /></p>
+        <p><span class="dia white"> Ah! Where's my -?</span></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right">
+        <p><span class="dia white"> ...Phantom?!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/ar8KEQP.png" height="auto" /></p>
+    </div>
+
+    <div class="convo-right">
+        <p><span class="dia white"> ...show a ghost's 'bare' truth. That's what it's supposed to do...</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0f8vOZo.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> How did you-?!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/Pk5wXAw.png" height="auto" /></p>
+    </div>
+   
+    <div class="convo-right">
+        <p><span class="dia white"> Wait is that...Jack Fenton branded underwear?!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/7U4pVLw.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/FPNurOW.png" height="auto" /></p>
+        <p><span class="dia white"> I'm!! I-!! It wasn't supposed to be like <em>this</em>!</span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/xOv3HTV.png" height="auto" /></p>
+        <p><span class="dia white"> This is so embarassing!!</span></p>
+    </div>
+    
+    <div class="convo-right">
+        <p><span class="dia white"> Are you...Danny?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/goGmH20.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> So our inventions... worked? </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0f8vOZo.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> Always worked?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/NMTRVWE.png" height="auto" /></p>
+    </div>
+
+</div>
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+
+<div class="convo-container gz2">
+    <div class="convo-right">
+        <p><span class="dia white">Aww that wasn't so bad </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/lBm6JuI.png" height="auto" /></p>
+        <p><span class="dia white"> I was dying of embarrassment! Literally! </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/d73MWT7.png" height="auto" /></p>
+        <p><span class="dia white"> Don't tell me <em>you</em> weren't dying of second hand embarassment.  </span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> Okay, I won't. </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/Fr3ryh8.png" height="auto" /></p>
+        <p><span class="dia white"> I told myself I wouldn't be caught <em>dead</em> in that underwear! Ever!  </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/YLIBJth.png" height="auto" /></p>
+        <p><span class="dia white"> But somehow I was! I can't believe it! </span></p>
+    </div>
+</div>
+
+
+<div class="convo-container">
+    <img class="absolute" src="https://i.giphy.com/media/i2tLw5ZyikSFdkeGHT/giphy.webp" /><a class="cyoa-start-over" href="#start">
+        <span>Start Over =></span>
+    </a>
+</div>
+
+<!-- show fake footer -->
+<h3 class="anh region">Notes:</h3>
+<p class="fakenotes region">The Bare Necessities.</p>
+<p class="bline actions">
+    <a class="button-end"><span class="topb">
+        ↑ Top
+        <img src="https://i.imgur.com/RJmQlzw.png" />
+    </span></a>
+    <a class="button-end"><span class="kudosb">
+        Kudos ♥ 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+    <a class="button-end"><span class="collectionb">
+        Add to Collections 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+    <a class="button-end"><span class="bookmarkb">
+        Bookmark 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+    <a class="button-end"><span class="commentsb">
+        Comments (2) 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+</p>
+<p class="convo-break"></p>
+<!-- show cw warning the readers lol -->
+<div class="convo-container tall">
+    <div class="convo-right">
+        <p><span class="dia white ">Okay I love time travel as much as you readers...But man...the second hand embarassment...</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right convo-hidden">
+        <p><span class="dia white">Danny are you sure you're passing English?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/o37c8XC.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right convo-hidden">
+        <p><span class="dia white">I'm technically not supposed to, but do you want me to make any time-stasis bubbles for extra study time?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/o37c8XC.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right convo-hidden">
+        <p><span class="dia white">This loop makes me think you need it.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+</div>
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+</div>
+
+<div name="ask-none" class="ask-none tab secondary logged-in white-overflow">
+<div class="convo-container">
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/BDlGgi9.png" height="auto" /></p>
+        <p><span class="dia white">Nah I don't need to ask anyone for advice</span></p>
+    </div>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/5UWh1ug.png" height="auto" /></p>
+        <p><span class="dia white">Who knows me better than me? </span></p>
+    </div>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/LUaJ80t.png" height="auto" /></p>
+        <p><span class="dia white">They just need to see me transform. </span></p>
+    </div>
+</div>
+<br /><br />
+<div class="convo-container living-room">
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/mpSroxY.png" height="auto" /></p>
+        <p><span class="dia white">Hey Mom, Dad? Can you guys come in the living room? There's something I need to show you. </span></p>
+    </div>
+    
+    <div class="convo-right"> 
+        <p><span class="dia white">Sure Danny! Be right there!</span></p>
+        <!-- <p><img class="convo-icon" src="https://i.imgur.com/7U4pVLw.png" height="auto" /></p> -->
+    </div>
+
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://cdn.discordapp.com/attachments/886029945237823528/896388268722110485/Untitled_Artwork.gif" height="auto" /></p>
+        <p><span class="dia-thinking thinking-small white">(Should I start out as Fenton? Or as Phantom? Which would have a better effect?)</span></p>
+    </div>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/vYz0Si3.png" height="auto" /></p>
+        <p><span class="dia-thinking thinking-small white">(I mean it's not like they've never seen Phantom around the house - and - )</span></p>
+    </div>
+    
+    <div class="convo-right"> 
+        <p><span class="dia white">Here, Danny! Where are you?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/7U4pVLw.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/kSFAv10.png" height="auto" /></p>
+        <p><span class="dia white">Ah-!</span></p>
+    </div>
+    <p class="convo-break"></p>
+
+    <div class="convo-right"> 
+        <p><span class="dia-thinking thinking-small white">(What's Phantom doing here?)</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/M29yaUj.png" height="auto" /></p>
+    </div>
+
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/lBm6JuI.png" height="auto" /></p>
+        <p><span class="dia white">I have a confession! I'm the ghost boy!</span></p>
+    </div>
+    <div class="convo-right"> 
+        <p><span class="dia white">Um... We know?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/Pk5wXAw.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/m0UaAxJ.png" height="auto" /></p>
+        <p><span class="dia white">You do? </span></p>
+    </div>
+    <div class="convo-right"> 
+        <p><span class="dia white">I mean, it's pretty obvious?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0f8vOZo.png" height="auto" /></p>
+    </div>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/YLIBJth.png" height="auto" /></p>
+        <p><span class="dia white">It is?! Why didn't anyone figure it out? Why didn't you say anything?</span></p>
+    </div>
+    <div class="convo-right"> 
+        <p><span class="dia white">What's there to say?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0f8vOZo.png" height="auto" /></p>
+    </div>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/3EsrGVC.png" height="auto" /></p>
+        <p><span class="dia white">So you're not mad? Or upset? </span></p>
+    </div>
+    <div class="convo-right"> 
+        <p><span class="dia white">I'm just confused. What are you doing in our house?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/goGmH20.png" height="auto" /></p>
+    </div>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/bKtuWGZ.png" height="auto" /></p>
+        <p><span class="dia white">No obviously I li-</span></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/3XG8tw3.png" height="auto" /></p>
+        <p><span class="dia white"> Oh. </span></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/YLIBJth.png" height="auto" /></p>
+        <p><span class="dia white"> OH. </span></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/YLIBJth.png" height="auto" /></p>
+        <p><span class="dia white">I'm a ghost.</span></p>
+    </div>
+    <div class="convo-right"> 
+        <p><span class="dia white">Yes. we established that earlier.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/Pk5wXAw.png" height="auto" /></p>
+    </div>
+    <div class="convo-right"> 
+        <p><span class="dia white">Is this some ghost version of April Fool's? That was a few days ago.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0f8vOZo.png" height="auto" /></p>
+    </div>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/f4LW6D6.png" height="auto" /></p>
+        <p><span class="dia white">I- I messed up.</span></p>
+    </div>
+</div>
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<div class="convo-container gz2">
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/YLIBJth.png" height="auto" /></p>
+        <p><span class="dia white">Clockwork! I need to -</span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white">"Try that again"? Are you sure?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/uK9Zatn.png" height="auto" /></p>
+        <p><span class="dia white">Yes! I don't want any misunderstandings! </span></p>
+    </div>
+
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/lBm6JuI.png" height="auto" /></p>
+        <p><span class="dia white">This probably wouldn't have happened if I had <em>2 extra seconds</em> 
+            to just see myself in the mirror!</span></p>
+    </div>
+    <div class="convo-left"> 
+        <p><img class="convo-icon" src="https://i.imgur.com/YLIBJth.png" height="auto" /></p>
+        <p><span class="dia white">But there's no mirrors in the living room!</span></p>
+    </div>
+
+    <div class="convo-right">
+        <p><span class="dia white">Mirror mirror on the wall, whos the fairest of them all?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+</div>
+
+<div class="convo-container">
+    <img class="absolute" src="https://i.giphy.com/media/i2tLw5ZyikSFdkeGHT/giphy.webp" /><a class="cyoa-start-over" href="#start">
+        <span>Start Over =></span>
+    </a>
+</div>
+
+<!-- show fake footer -->
+<h3 class="anh region">Notes:</h3>
+<p class="fakenotes region">Danny pls.</p>
+<p class="bline actions">
+    <a class="button-end"><span class="topb">
+        ↑ Top
+        <img src="https://i.imgur.com/RJmQlzw.png" />
+    </span></a>
+    <a class="button-end"><span class="kudosb">
+        Kudos ♥ 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+    <a class="button-end"><span class="collectionb">
+        Add to Collections 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+    <a class="button-end"><span class="bookmarkb">
+        Bookmark 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+    <a class="button-end"><span class="commentsb">
+        Comments (2) 
+        <img src="https://i.imgur.com/RJmQlzw.png" /></span></a>
+</p>
+<p class="convo-break"></p>
+<!-- show cw warning the readers lol -->
+<div class="convo-container tall">
+    <!-- or: even the author is speechless -->
+    <div class="convo-right">
+        <p><span class="dia white"> Even the author is speechless.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right convo-hidden">
+        <p><span class="dia white"> Okay this was probably my favorite loop.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/o37c8XC.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right convo-hidden">
+        <p><span class="dia white"> Too bad it wasn't the one that worked.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/o37c8XC.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right convo-hidden">
+        <p><span class="dia white">Let's start over.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
+    </div>
+</div>
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br /><br />
+</div>
+
+<div name="vent" class="vent tab">
+<div class="phone">
+    <br>
+    <p class="messagebody">
+        <span class="header">Jazz the Spazz</span><br /><br />
+        
+        <span class="breply">jazz</span><br />
+
+        <span class="breply">why does everything i ever try end in disaster</span><br />
+        <span class="breply">i cant ever succeed</span><br />
+
+        <span class="text">are you okay</span><br />
+        <span class="text">where are you rn</span><br />
+        <span class="breply">in my room</span><br />
+
+        <span class="text">ill come over</span><br />
+    </p>
+</div>
+<br /><br />
+
+<div class="convo-container room">
+    <div class="convo-right">
+        <p><span class="dia white"> Danny, is everything okay?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/9j4scKV.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/dhU1LQC.png" height="auto" /></p>
+        <p><span class="dia white"> So I've been trying to tell Mom and Dad that I'm... you know </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/Arptb9D.png" height="auto" /></p>
+        <p><span class="dia white"> That I'm a half ghost. That I'm Phantom. </span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> And... how did it go?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/ZntJwjr.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/a8wCXEU.png" height="auto" /></p>
+        <p><span class="dia white"> I've tried telling them so many times, Jazz. </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/u0m8t9c.png" height="auto" /></p>
+        <p><span class="dia white"> But I mess up, a lot. So... I used time travel to undo it. </span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> Wait you can TI-! </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/MXdB4hi.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right">
+        <p><span class="dia white"> Nevermind. </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/q0Zpvw7.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> What have you tried so far? What happened that you had to undo it?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/9j4scKV.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/TZVxzXS.png" height="auto" /></p>
+        <p><span class="dia white"> I've tried approaching them as Fenton, I've tried approaching them as Phantom.</span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/dhU1LQC.png" height="auto" /></p>
+        <p><span class="dia white"> They keep misunderstanding or I do something wrong and 
+            then I go back in time to fix it so that I can start over again  </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/CF0bJOg.png" height="auto" /></p>
+        <p><span class="dia white"> I have to do this right. I don't want Mom and Dad to be... <em>embarrassed</em> by me.  </span></p>
+    </div>
+    <div class="convo-right">
+        <!-- jazz is nervous bc she notices they might have eavesdroppers -->
+        <p><span class="dia white"> ...</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/aOsUsc0.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right">
+        <p><span class="dia white"> Mom and Dad are -</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/9j4scKV.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/u0m8t9c.png" height="auto" /></p>
+        <p><span class="dia white"> Sure I've made mistakes, but I want them to be proud of me. First impressions matter, 
+            and I'll try as many times as it takes to make a good one.</span></p>
+    </div>
+         
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/kt9Q4xF.png" height="auto" /></p>
+        <p><span class="dia white"> I wanna tell them that I, Danny Fenton, am the ghost boy Danny Phantom, 
+            and I don't want them to shoot at me or freak out about it. Is that too much to ask?
+        </span></p>
+    </div>
+</div>
+<br /><br />
+
+<!-- door open image and comic book noise effect behind it -->
+<div class="img-container"> 
+    <img class="img-holder img-eavesdrop " src="https://i.imgur.com/cTOdGPK.png" />
+    <img class="img-holder" src="https://i.imgur.com/b5lT0rl.png" />
+</div>
+
+<div class="convo-container room">        
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/BXJK9Pk.png" height="auto" /></p>
+        <p><span class="dia white"> Mom, Dad ...! How much - </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/bS4C77o.png" height="auto" /></p>
+        <p><span class="dia white"> Um! Uh...that was just... something I was practicing for school!  </span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> That didn't sound like it was for school </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/NMTRVWE.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> Are you really, ...?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/goGmH20.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/RBVwfYX.png" height="auto" /></p>
+        <p><span class="dia white"> ... </span></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/dhU1LQC.png" height="auto" /></p>
+        <p><span class="dia white"> ...yeah </span></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right">
+        <p><span class="dia white"> And we shot at you?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/goGmH20.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> We... shot at Phantom. Tried to capture him all the time.  </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/NMTRVWE.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> And that was you! Somehow, I don't know how!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/1YYfREo.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> But that means we hurt you, didn't we?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/goGmH20.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> Oh, Danny I'm so sorry I wish we- </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/goGmH20.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/PSY7lYI.png" height="auto" /></p>
+        <p><span class="dia white"> This is also what I was afraid of! </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/a8wCXEU.png" height="auto" /></p>
+        <p><span class="dia white"> It's not your fault! It was just a misunderstanding! </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/Tm7dceH.png" height="auto" /></p>
+        <p><span class="dia white"> Okay I'll just start over and try again and - </span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> Danny wait! You don't have to start over! Please!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/9j4scKV.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> We are proud of you!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/tLV1l7L.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> We were never embarrassed by you. </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/reh7adS.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> And while we still hunt ghosts, we've stopped actively hunting Phantom. 
+            We recognized the good he was doing for Amity Park.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/tLV1l7L.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> The actions you took as Phantom probably make more sense now that we know you were behind it. </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/mo6UaK3.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> It's been months since we've last hunt ghosts anyway. </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/0f8vOZo.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> Oh my goodness it's been months! Danny you've been a ghost for so long!</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/goGmH20.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/TZVxzXS.png" height="auto" /></p>
+        <p><span class="dia white"> ...half ghost, actually </span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> What does that even mean?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/goGmH20.png" height="auto" /></p>
+    </div>
+    
+    <div class="convo-right">
+        <p><span class="dia white"> Danny, Mom and Dad would have freaked out a little bit when they found out, no matter what. </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/ZntJwjr.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> And that's okay. What matters is what happens <em>after</em> the freak out. </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/OVq62LU.png" height="auto" /></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> There's a lot we don't know about all this, but we can figure it out, together. </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/reh7adS.png" height="auto" /></p>
+    </div>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/c8ZxyPL.png" height="auto" /></p>
+        <p><span class="dia white"> Thanks Mom, Thanks Dad. And thanks, Jazz.  </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/J12HKH5.png" height="auto" /></p>
+        <p><span class="dia white"> Speaking of together. </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/BDlGgi9.png" height="auto" /></p>
+        <p><span class="dia white"> Do you think we could figure this out with a together + 1? </span></p>
+    </div>
+
+    <div class="convo-right">
+        <p><span class="dia white"> What do you mean?</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/1YYfREo.png" height="auto" /></p>
+    </div>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/J12HKH5.png" height="auto" /></p>
+        <p><span class="dia white"> I mean, there's another half ghost, and she has no where to go, so I thought... </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/VFIkUBp.png" height="auto" /></p>
+        <p><span class="dia white"> It'd be nice for her to stay with us. As part of our family. </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/c8ZxyPL.png" height="auto" /></p>
+        <p><span class="dia white"> It'll make more sense when you meet her. </span></p>
+    </div>
+</div>
+<br /><br /><br /><br />
+<div class="convo-container">
+    <p>A few hours later</p>
+</div>
+<br /><br /><br /><br />
+    
+<div class="convo-container amity-night">
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/BDlGgi9.png" height="auto" /></p>
+        <p><span class="dia white"> Elle, we're here </span></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-right">
+        <p><span class="dia white"> Um... hi there </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/jIzdHqf.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/V6YL1rH.png" height="auto" /></p>
+        <p><span class="dia white"> She looks just like...! </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/Ty0tLiJ.png" height="auto" /></p>
+        <p><span class="dia white"> Like Jazz when she was younger! </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/V6YL1rH.png" height="auto" /></p>
+        <p><span class="dia white"> Like she could be your sister or cousin!</span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/Arptb9D.png" height="auto" /></p>
+        <p><span class="dia white"> And just like me, she's a half ghost too.  </span></p>
+    </div>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/5EavB1I.png" height="auto" /></p>
+        <p><span class="dia white"> What happened to you, to turn you into a half ghost?</span></p>
+    </div>
+
+    <div class="convo-right">
+        <p><span class="dia white"> It's... a long story.  </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/pb5mDSQ.png" height="auto" /></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/qHg7TRX.png" height="auto" /></p>
+        <p><span class="dia white"> ...</span></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/MEMdwtc.png" height="auto" /></p>
+        <p><span class="dia white"> ...</span></p>
+    </div>
+    <p class="convo-break"></p>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/n61o9aE.png" height="auto" /></p>
+        <p><span class="dia white"> Elle, Danny tells us you don't have anywhere to go, is that true?</span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> Uh, technically, yes.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/jIzdHqf.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/n61o9aE.png" height="auto" /></p>
+        <p><span class="dia white"> Why "technically"?</span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> I stayed with Vl- with a crazy fruitloop. Left a few months ago. Been traveling around the world and the ghost zone since.</span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/XWSQJez.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/IEjx3VI.png" height="auto" /></p>
+        <p><span class="dia white"> That's no way for a young girl to live! You should be in school, get bear hugs, and lots of fudge and -</span></p>
+    </div>
+
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/mlPZyO8.png" height="auto" /></p>
+        <p><span class="dia white"> Elle, would you like to stay with us? As a Fenton?</span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/skq6FAV.png" height="auto" /></p>
+        <p><span class="dia white"> You don't have to tell us right away, how you came to be a half ghost -</span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/V6YL1rH.png" height="auto" /></p>
+        <p><span class="dia white"> - or at all!</span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/mlPZyO8.png" height="auto" /></p>
+        <p><span class="dia white"> But whatever that means, we can stand by your side and help</span></p>
+    </div>
+    <div class="convo-right">
+        <p><span class="dia white"> I'd love that!  </span></p>
+        <p><img class="convo-icon" src="https://i.imgur.com/1MBbKpC.png" height="auto" /></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/J12HKH5.png" height="auto" /></p>
+        <p><span class="dia white"> Sorry it took so long, Elle.  </span></p>
+    </div>
+    <div class="convo-left">
+        <p><img class="convo-icon" src="https://i.imgur.com/c8ZxyPL.png" height="auto" /></p>
+        <p><span class="dia white"> Welcome home. </span></p>
+    </div>
+</div>
+</div>
+
+
+</figure>

--- a/Quaranteens/quarantine-6v3.html
+++ b/Quaranteens/quarantine-6v3.html
@@ -41,12 +41,6 @@ eventual order for copy paste:
  -->
 
 <figure>
-<a id="tab0" name="tab0"></a>
-<div name="tab0" class="tab0 tab secondary logged-in white-overflow">
-    yo we got a hacker here?
-    <a href="#root">start over</a>
-</div>
-
 <a id="start" name="start"></a>
 <a id="start2" name="start2"></a>
 <a id="root" name="root"></a>
@@ -329,7 +323,6 @@ eventual order for copy paste:
         <p><img class="convo-icon" src="https://i.imgur.com/0TDqcrx.png" height="auto" /></p>
     </div>
 </div>
-</div>
 
 <br /><br /><br /><br /><br /><br />
 <br /><br /><br /><br /><br /><br />
@@ -337,7 +330,7 @@ eventual order for copy paste:
 <br /><br /><br /><br /><br /><br />
 <br /><br /><br /><br /><br /><br />
 <br /><br /><br /><br /><br /><br />
-<!-- </div> -->
+</div>
 
 <div name="ask-elle" class="ask-elle tab secondary logged-in white-overflow">
 <div class="dm-container">
@@ -2195,6 +2188,4 @@ eventual order for copy paste:
     </div>
 </div>
 </div>
-
-
 </figure>


### PR DESCRIPTION
* no js!
* actually thats a lie, there is some js.
* remove the dependency for progress tracking from the repl -- instead, hijack ao3s `setupAccordion` js function as a state toggler. 
* visit any 1 of 4 routes first. once at least 1 route has been visited, reveal the option of the 5th route. once all 5 routes have been visited, reveal the 6th route
  * on click, `.collapsed` turns into `.expanded`. count the number of `.expanded` to reveal the 5th and 6th choices as needed
  * while the repl version relied on clicking "start over" this relies on clicking "ask-*"
* keep all dialogue segments, fake author notes, and CW commentary the same -- restructure html , and write a lot of css to make this happen
* currently this requires :has selector, which is supported on all browsers except firefox. 
* the workaround to remove reliance on :has selector messed w the html structure too much, 
  * ao3, flex box when??
* just saving this as a draft so that when firefox DOES support :has, (or, css4 comes out, or ao3 supports flex boxes), i can update this and remove the reliance on external js entirely.
* this started a proof of concept of hijacking ao3s `setupAccordion` function (it worked, yay!) for future cyoas, but ended up in its own rabbit hole. 
* todo: eventually combine the repeated display blocks / display nones into chunks that make sense, add comments on some of the obtuse css, create a readme to explain whats going on 